### PR TITLE
Fix SpellArchive model lookup /errorspam

### DIFF
--- a/src/main/java/com/spellarchives/client/SpellArchiveModelRetexture.java
+++ b/src/main/java/com/spellarchives/client/SpellArchiveModelRetexture.java
@@ -17,7 +17,6 @@ import net.minecraft.client.renderer.vertex.DefaultVertexFormats;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.client.event.ModelBakeEvent;
 import net.minecraftforge.client.model.IModel;
-import net.minecraftforge.client.model.ModelLoader;
 import net.minecraftforge.client.model.ModelLoaderRegistry;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
@@ -85,7 +84,7 @@ public final class SpellArchiveModelRetexture {
                 }
             }
 
-            ModelResourceLocation modelLocation = new ModelResourceLocation(new ResourceLocation(SpellArchives.MODID, basePath), variant);
+            ModelResourceLocation modelLocation = new ModelResourceLocation(baseLoc, variant);
 
             IBakedModel existingModel = event.getModelRegistry().getObject(modelLocation);
             if (existingModel == null) {
@@ -166,9 +165,6 @@ public final class SpellArchiveModelRetexture {
 
                 // Register under the actual per-books path so blockstate resolves without reload
                 event.getModelRegistry().putObject(modelLocation, bakedModel);
-                // Also register under the canonical 'spell_archive' path for safety (books property included in variant)
-                ModelResourceLocation canonicalLoc = new ModelResourceLocation(baseLoc, variant);
-                event.getModelRegistry().putObject(canonicalLoc, bakedModel);
 
             } catch (Exception e) {
                 SpellArchives.LOGGER.error("Failed to retexture spell archive model for " + variant, e);


### PR DESCRIPTION
## Fix SpellArchive variant lookup

This PR fixes `SpellArchiveModelRetexture` to use the canonical blockstate root for baked model lookup.

`spell_archive` is the only blockstate root for this block. The `books` value is a blockstate property, while `spell_archive_1` through `spell_archive_14` are model files under `models/block/`.

Before this change, the bake code used `spell_archive_1`, `spell_archive_2`, etc. as the `ModelResourceLocation` root, which caused invalid lookups:

```text
18:15:23] [Client thread/DEBUG] [VintageFix]: Error loading model block definition
org.embeddedt.vintagefix.util.FastFileNotFoundException: spellarchives:blockstates/spell_archive_1.json
[18:15:23] [Client thread/ERROR] [org.embeddedt.vintagefix.dynamicresources.model.DynamicModelProvider]: Failed to load model spellarchives:spell_archive_1#books=1,facing=north
org.embeddedt.vintagefix.dynamicresources.model.DynamicModelProvider$DynamicModelLoadFailException: Variant spellarchives:spell_archive_1#books=1,facing=north does not exist
[18:15:23] [Client thread/ERROR] [org.embeddedt.vintagefix.dynamicresources.model.DynamicModelProvider]: Failed to load model spellarchives:spell_archive_1#books=1,facing=north as item spellarchives:spell_archive_1
org.embeddedt.vintagefix.dynamicresources.model.DynamicModelProvider$DynamicModelLoadFailException: Variant spellarchives:spell_archive_1#books=1,facing=north does not exist
[18:15:23] [Client thread/ERROR] [org.embeddedt.vintagefix.dynamicresources.model.DynamicBakedModelProvider]: Error occured while loading model spellarchives:spell_archive_1#books=1,facing=north
[18:15:23] [Client thread/ERROR] [org.embeddedt.vintagefix.dynamicresources.model.DynamicModelProvider]: Failed to load model spellarchives:spell_archive_1#books=1,facing=south
org.embeddedt.vintagefix.dynamicresources.model.DynamicModelProvider$DynamicModelLoadFailException: Variant spellarchives:spell_archive_1#books=1,facing=south does not exist
[18:15:23] [Client thread/ERROR] [org.embeddedt.vintagefix.dynamicresources.model.DynamicModelProvider]: Failed to load model spellarchives:spell_archive_1#books=1,facing=south as item spellarchives:spell_archive_1
org.embeddedt.vintagefix.dynamicresources.model.DynamicModelProvider$DynamicModelLoadFailException: Variant spellarchives:spell_archive_1#books=1,facing=south does not exist
[18:15:23] [Client thread/ERROR] [org.embeddedt.vintagefix.dynamicresources.model.DynamicBakedModelProvider]: Error occured while loading model spellarchives:spell_archive_1#books=1,facing=south
[18:15:23] [Client thread/ERROR] [org.embeddedt.vintagefix.dynamicresources.model.DynamicModelProvider]: Failed to load model spellarchives:spell_archive_1#books=1,facing=west
org.embeddedt.vintagefix.dynamicresources.model.DynamicModelProvider$DynamicModelLoadFailException: Variant spellarchives:spell_archive_1#books=1,facing=west does not exist
[18:15:23] [Client thread/ERROR] [org.embeddedt.vintagefix.dynamicresources.model.DynamicModelProvider]: Failed to load model spellarchives:spell_archive_1#books=1,facing=west as item spellarchives:spell_archive_1
org.embeddedt.vintagefix.dynamicresources.model.DynamicModelProvider$DynamicModelLoadFailException: Variant spellarchives:spell_archive_1#books=1,facing=west does not exist
[18:15:23] [Client thread/ERROR] [org.embeddedt.vintagefix.dynamicresources.model.DynamicBakedModelProvider]: Error occured while loading model spellarchives:spell_archive_1#books=1,facing=west
[18:15:23] [Client thread/ERROR] [VintageFix]: Suppressing further model loading errors for namespace 'spellarchives'
[18:15:23] [Client thread/DEBUG] [VintageFix]: Error loading model block definition
org.embeddedt.vintagefix.util.FastFileNotFoundException: spellarchives:blockstates/spell_archive_2.json
[18:15:23] [Client thread/DEBUG] [VintageFix]: Error loading model block definition
org.embeddedt.vintagefix.util.FastFileNotFoundException: spellarchives:blockstates/spell_archive_3.json
[18:15:23] [Client thread/DEBUG] [VintageFix]: Error loading model block definition
org.embeddedt.vintagefix.util.FastFileNotFoundException: spellarchives:blockstates/spell_archive_4.json
[18:15:23] [Client thread/DEBUG] [VintageFix]: Error loading model block definition
org.embeddedt.vintagefix.util.FastFileNotFoundException: spellarchives:blockstates/spell_archive_5.json
[18:15:23] [Client thread/DEBUG] [VintageFix]: Error loading model block definition
org.embeddedt.vintagefix.util.FastFileNotFoundException: spellarchives:blockstates/spell_archive_6.json
[18:15:23] [Client thread/DEBUG] [VintageFix]: Error loading model block definition
org.embeddedt.vintagefix.util.FastFileNotFoundException: spellarchives:blockstates/spell_archive_7.json
[18:15:23] [Client thread/DEBUG] [VintageFix]: Error loading model block definition
org.embeddedt.vintagefix.util.FastFileNotFoundException: spellarchives:blockstates/spell_archive_8.json
[18:15:23] [Client thread/DEBUG] [VintageFix]: Error loading model block definition
org.embeddedt.vintagefix.util.FastFileNotFoundException: spellarchives:blockstates/spell_archive_9.json
[18:15:23] [Client thread/DEBUG] [VintageFix]: Error loading model block definition
org.embeddedt.vintagefix.util.FastFileNotFoundException: spellarchives:blockstates/spell_archive_10.json
[18:15:23] [Client thread/DEBUG] [VintageFix]: Error loading model block definition
org.embeddedt.vintagefix.util.FastFileNotFoundException: spellarchives:blockstates/spell_archive_11.json
[18:15:23] [Client thread/DEBUG] [VintageFix]: Error loading model block definition
org.embeddedt.vintagefix.util.FastFileNotFoundException: spellarchives:blockstates/spell_archive_12.json
[18:15:23] [Client thread/DEBUG] [VintageFix]: Error loading model block definition
org.embeddedt.vintagefix.util.FastFileNotFoundException: spellarchives:blockstates/spell_archive_13.json
[18:15:23] [Client thread/DEBUG] [VintageFix]: Error loading model block definition
org.embeddedt.vintagefix.util.FastFileNotFoundException: spellarchives:blockstates/spell_archive_14.json
[18:15:24] [Client thread/DEBUG] [VintageFix]: Error loading model block definition

```

errors like:  `spell_archive_1#books=...` lookups are gone and the archive variants render correctly in game.